### PR TITLE
feat: split personalities across tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ buttons appear beneath the greeting that new members see.
 Environment variables:
 
 - `BOT_TOKEN` – Telegram bot token
+- `BOT_TOKENS` – comma-separated list of `Personality:token` pairs. The bot with
+  personality `JoePeach` acts as the admin bot and sends greetings.
 - `ADMIN_ID` – Telegram user id of the admin
 - `GROUP_ID` – chat id of the group
 - `DEEPSEEK_API_KEY` – token for DeepSeek API

--- a/bot/config.py
+++ b/bot/config.py
@@ -15,6 +15,23 @@ except Exception:
     _LOGURU = False
 
 BOT_TOKEN = os.getenv("BOT_TOKEN")
+# expected format: "Kuplinov:token1,JoePeach:token2"
+_BOT_TOKENS_RAW = os.getenv("BOT_TOKENS", "").strip()
+BOT_TOKENS: dict[str, str] = {}
+if _BOT_TOKENS_RAW:
+    for part in _BOT_TOKENS_RAW.replace(";", ",").split(","):
+        part = part.strip()
+        if not part or ":" not in part:
+            continue
+        key, token = part.split(":", 1)
+        key = key.strip()
+        token = token.strip()
+        if key and token:
+            BOT_TOKENS[key] = token
+
+# fallback for single-bot setup
+if BOT_TOKEN and not BOT_TOKENS:
+    BOT_TOKENS = {"default": BOT_TOKEN}
 ADMIN_ID = int(os.getenv("ADMIN_ID", "0"))
 _GROUP_IDS_RAW = os.getenv("GROUP_IDS", "").strip()
 _GROUP_ID_SINGLE = os.getenv("GROUP_ID", "0").strip()

--- a/bot/handlers/__init__.py
+++ b/bot/handlers/__init__.py
@@ -1,5 +1,6 @@
 from aiogram import Dispatcher, F
 from aiogram.filters import Command, StateFilter
+from functools import partial
 
 from ..config import ADMIN_ID
 from ..states import (
@@ -13,41 +14,46 @@ from ..states import (
 from . import admin, common
 
 
-def register_handlers(dp: Dispatcher) -> None:
-    dp.message.register(admin.cmd_start, Command("start"), F.from_user.id == ADMIN_ID, F.chat.type == "private")
-    dp.message.register(admin.cmd_chatid, Command("chatid"))
+def register_handlers(dp: Dispatcher, personality: str) -> None:
+    if personality == "JoePeach":
+        dp.message.register(admin.cmd_start, Command("start"), F.from_user.id == ADMIN_ID, F.chat.type == "private")
+        dp.message.register(admin.cmd_chatid, Command("chatid"))
 
-    dp.callback_query.register(admin.cmd_set_greeting, F.data == "menu_greeting", F.from_user.id == ADMIN_ID)
-    dp.callback_query.register(admin.cmd_set_question, F.data == "menu_question", F.from_user.id == ADMIN_ID)
-    dp.callback_query.register(admin.cmd_buttons, F.data == "menu_buttons", F.from_user.id == ADMIN_ID)
-    dp.callback_query.register(admin.show_buttons_for_delete, F.data == "btn_del", F.from_user.id == ADMIN_ID)
-    dp.callback_query.register(admin.show_buttons_for_edit, F.data == "btn_edit", F.from_user.id == ADMIN_ID)
-    dp.callback_query.register(admin.process_button_add, F.data == "btn_add", F.from_user.id == ADMIN_ID)
-    dp.callback_query.register(admin.process_button_delete, F.data.startswith("delbtn:"), F.from_user.id == ADMIN_ID)
-    dp.callback_query.register(
-        admin.process_button_edit_select,
-        F.data.startswith("editbtn:"),
-        F.from_user.id == ADMIN_ID,
-        StateFilter("*"),
-    )
-    dp.callback_query.register(admin.cmd_kuplinov_menu, F.data == "menu_kuplinov", F.from_user.id == ADMIN_ID)
-    dp.callback_query.register(admin.process_kp_add, F.data == "kp_add", F.from_user.id == ADMIN_ID)
-    dp.callback_query.register(admin.process_kp_del, F.data == "kp_del", F.from_user.id == ADMIN_ID)
-    dp.callback_query.register(admin.process_kp_list, F.data == "kp_list", F.from_user.id == ADMIN_ID)
-    dp.callback_query.register(admin.send_preview, F.data == "menu_preview", F.from_user.id == ADMIN_ID)
-    dp.callback_query.register(admin.back_main, F.data == "back_main", F.from_user.id == ADMIN_ID)
+        dp.callback_query.register(admin.cmd_set_greeting, F.data == "menu_greeting", F.from_user.id == ADMIN_ID)
+        dp.callback_query.register(admin.cmd_set_question, F.data == "menu_question", F.from_user.id == ADMIN_ID)
+        dp.callback_query.register(admin.cmd_buttons, F.data == "menu_buttons", F.from_user.id == ADMIN_ID)
+        dp.callback_query.register(admin.show_buttons_for_delete, F.data == "btn_del", F.from_user.id == ADMIN_ID)
+        dp.callback_query.register(admin.show_buttons_for_edit, F.data == "btn_edit", F.from_user.id == ADMIN_ID)
+        dp.callback_query.register(admin.process_button_add, F.data == "btn_add", F.from_user.id == ADMIN_ID)
+        dp.callback_query.register(admin.process_button_delete, F.data.startswith("delbtn:"), F.from_user.id == ADMIN_ID)
+        dp.callback_query.register(
+            admin.process_button_edit_select,
+            F.data.startswith("editbtn:"),
+            F.from_user.id == ADMIN_ID,
+            StateFilter("*"),
+        )
+        dp.callback_query.register(admin.cmd_kuplinov_menu, F.data == "menu_kuplinov", F.from_user.id == ADMIN_ID)
+        dp.callback_query.register(admin.process_kp_add, F.data == "kp_add", F.from_user.id == ADMIN_ID)
+        dp.callback_query.register(admin.process_kp_del, F.data == "kp_del", F.from_user.id == ADMIN_ID)
+        dp.callback_query.register(admin.process_kp_list, F.data == "kp_list", F.from_user.id == ADMIN_ID)
+        dp.callback_query.register(admin.send_preview, F.data == "menu_preview", F.from_user.id == ADMIN_ID)
+        dp.callback_query.register(admin.back_main, F.data == "back_main", F.from_user.id == ADMIN_ID)
 
-    dp.message.register(admin.process_greeting, GreetingState.waiting)
-    dp.message.register(admin.process_question, QuestionState.waiting)
-    dp.message.register(admin.process_button_label, ButtonAddState.waiting_label)
-    dp.message.register(admin.process_button_response, ButtonAddState.waiting_response)
-    dp.message.register(admin.process_button_edit_response, ButtonEditState.waiting_response)
-    dp.message.register(admin.process_kp_add_id, KuplinovAddState.waiting_id)
-    dp.message.register(admin.process_kp_del_id, KuplinovDelState.waiting_id)
+        dp.message.register(admin.process_greeting, GreetingState.waiting)
+        dp.message.register(admin.process_question, QuestionState.waiting)
+        dp.message.register(admin.process_button_label, ButtonAddState.waiting_label)
+        dp.message.register(admin.process_button_response, ButtonAddState.waiting_response)
+        dp.message.register(admin.process_button_edit_response, ButtonEditState.waiting_response)
+        dp.message.register(admin.process_kp_add_id, KuplinovAddState.waiting_id)
+        dp.message.register(admin.process_kp_del_id, KuplinovDelState.waiting_id)
 
-    dp.message.register(common.welcome, F.new_chat_members)
-    dp.message.register(common.cmd_kuplinov, Command("kuplinov"))
-    dp.message.register(common.cmd_joepeach, Command("joepeach"))
-    dp.message.register(common.cmd_mrazota, Command("mrazota"))
+        dp.message.register(common.welcome, F.new_chat_members)
+
+    if personality == "Kuplinov":
+        dp.message.register(common.cmd_kuplinov, Command("kuplinov"))
+    elif personality == "JoePeach":
+        dp.message.register(common.cmd_joepeach, Command("joepeach"))
+    elif personality == "Mrazota":
+        dp.message.register(common.cmd_mrazota, Command("mrazota"))
     dp.callback_query.register(common.on_button, F.data.startswith("btn:"))
-    dp.message.register(common.handle_message, F.text)
+    dp.message.register(partial(common.handle_message, personality_key=personality), F.text)

--- a/bot/history.py
+++ b/bot/history.py
@@ -22,7 +22,10 @@ async def get_history(chat_id: int, limit: int = 10) -> list[str]:
     return await redis.lrange(key, -limit, -1)
 
 
-async def increment_count(chat_id: int) -> bool:
+async def increment_count(chat_id: int, msg_id: int) -> bool:
+    last_key = f"chat:{chat_id}:last_msg"
+    if not await redis.set(last_key, msg_id, nx=True, ex=60):
+        return False
     key = f"chat:{chat_id}:count"
     val = await redis.incr(key)
     if val >= 10:

--- a/main.py
+++ b/main.py
@@ -4,21 +4,29 @@ from aiogram import Bot, Dispatcher
 from aiogram.enums import ParseMode
 from aiogram.fsm.storage.memory import MemoryStorage
 
-from bot.config import BOT_TOKEN, setup_logging, logger
+from bot.config import BOT_TOKENS, setup_logging, logger
 from bot.db import init_db
 from bot.history import init_history
 from bot.handlers import register_handlers
+
+
+async def _start_single_bot(token: str, personality: str) -> None:
+    bot = Bot(token=token, parse_mode=ParseMode.HTML)
+    dp = Dispatcher(storage=MemoryStorage())
+    register_handlers(dp, personality)
+    logger.info(f"bot {personality} started")
+    await dp.start_polling(bot)
 
 
 async def main() -> None:
     await init_db()
     await init_history()
     setup_logging()
-    bot = Bot(token=BOT_TOKEN, parse_mode=ParseMode.HTML)
-    dp = Dispatcher(storage=MemoryStorage())
-    register_handlers(dp)
-    logger.info("bot started")
-    await dp.start_polling(bot)
+    tasks = [
+        asyncio.create_task(_start_single_bot(token, personality))
+        for personality, token in BOT_TOKENS.items()
+    ]
+    await asyncio.gather(*tasks)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow configuring multiple bot tokens and personalities
- ensure each bot handles only its personality
- avoid naming personality in replies and share random message counter
- dedicate JoePeach as the sole admin bot and greeter

## Testing
- `python -m py_compile main.py bot/config.py bot/handlers/__init__.py bot/handlers/common.py bot/history.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ca5366ed4832096cdd7289862abcc