### PR TITLE
feat: add random moods for personalities

### DIFF
--- a/bot/handlers/common.py
+++ b/bot/handlers/common.py
@@ -18,7 +18,7 @@ from ..config import (
 )
 from ..db import check_rate, get_buttons, get_greeting, get_question
 from ..history import add_message, get_history, increment_count, redis
-from ..personalities import MAIN_PROMPT, SLANG_DICT, get_prompt
+from ..personalities import MAIN_PROMPT, SLANG_DICT, get_mood_prompt, get_prompt
 from ..utils import btn_id
 
 
@@ -122,12 +122,14 @@ async def on_button(query: CallbackQuery) -> None:
 
 def _build_prompt(personality_key: str, context: str, priority_text: str, additional_context: str) -> tuple[str, str]:
     prompt = get_prompt(personality_key)
+    mood = get_mood_prompt(personality_key)
     slang = ", ".join(f"{k}={v}" for k, v in SLANG_DICT.items())
     system_prompt = "\n".join(
         [
             MAIN_PROMPT,
             (f"Словарь сленга (ИСПОЛЬЗУЙ ТОЛЬКО ДЛЯ ПОНИМАНИЯ, НЕ ВСТАВЛЯЙ В ОТВЕТЫ): {slang}\n" if slang else ""),
             prompt,
+            mood,
             (additional_context if additional_context else ""),
             "Дальше от пользователя ты получишь историю чата:\n",
         ]

--- a/bot/personalities.py
+++ b/bot/personalities.py
@@ -1,3 +1,5 @@
+import random
+
 from .config import PROMPTS_DIR
 
 
@@ -27,4 +29,44 @@ def get_prompt(name: str) -> str:
         return file.read_text(encoding="utf-8")
     except Exception:
         return ""
+
+
+MOOD_PROMPTS: dict[str, str] = {
+    "игривое": "Ты в игривом настроении, подшучивай и дразни собеседника.",
+    "веселое": "Ты в веселом настроении, излучай позитив и шуми.",
+    "нейтральное": "У тебя нейтральное настроение, отвечай спокойно и ровно.",
+    "злое": "Ты в злом настроении, можно огрызаться и саркастично подколоть.",
+    "агрессивное": "Ты в агрессивном настроении, можешь резко и грубо отвечать.",
+}
+
+
+# Вероятности настроений для разных личностей
+MOOD_WEIGHTS: dict[str, dict[str, int]] = {
+    "JoePeach": {
+        "игривое": 3,
+        "веселое": 3,
+        "нейтральное": 2,
+        "злое": 1,
+        "агрессивное": 1,
+    },
+    "Mrazota": {
+        "игривое": 1,
+        "веселое": 1,
+        "нейтральное": 2,
+        "злое": 3,
+        "агрессивное": 3,
+    },
+}
+
+
+def get_mood_prompt(personality: str) -> str:
+    """Return random mood prompt for selected personalities."""
+    weights = MOOD_WEIGHTS.get(personality)
+    if not weights:
+        return ""
+    moods = list(MOOD_PROMPTS.keys())
+    probs = [weights.get(mood, 1) for mood in moods]
+    mood = random.choices(moods, weights=probs, k=1)[0]
+    text = MOOD_PROMPTS[mood]
+    return f"Сейчас у тебя {mood} настроение. {text}"
 

--- a/tests/test_personalities.py
+++ b/tests/test_personalities.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.personalities import get_mood_prompt
+
+
+def test_get_mood_prompt_weights_joepeach():
+    with patch("bot.personalities.random.choices") as choices_mock:
+        choices_mock.return_value = ["игривое"]
+        get_mood_prompt("JoePeach")
+        _, kwargs = choices_mock.call_args
+        assert kwargs["weights"] == [3, 3, 2, 1, 1]
+
+
+def test_get_mood_prompt_weights_mrazota():
+    with patch("bot.personalities.random.choices") as choices_mock:
+        choices_mock.return_value = ["злое"]
+        get_mood_prompt("Mrazota")
+        _, kwargs = choices_mock.call_args
+        assert kwargs["weights"] == [1, 1, 2, 3, 3]
+
+
+def test_get_mood_prompt_unknown_personality():
+    assert get_mood_prompt("Unknown") == ""


### PR DESCRIPTION
## Summary
- add random mood prompts for JoePeach and Mrazota
- include mood line in prompt construction
- weight mood selection probabilities for each personality
- test mood weight handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ced1f27808320966379febafe683b