### PR TITLE
Add personality editing and threaded dialogue tracking

### DIFF
--- a/bot/handlers/__init__.py
+++ b/bot/handlers/__init__.py
@@ -9,6 +9,7 @@ from ..states import (
     GreetingState,
     KuplinovAddState,
     KuplinovDelState,
+    PersonalityEditState,
     QuestionState,
 )
 from . import admin, common
@@ -22,6 +23,7 @@ def register_handlers(dp: Dispatcher, personality: str) -> None:
         dp.callback_query.register(admin.cmd_set_greeting, F.data == "menu_greeting", F.from_user.id == ADMIN_ID)
         dp.callback_query.register(admin.cmd_set_question, F.data == "menu_question", F.from_user.id == ADMIN_ID)
         dp.callback_query.register(admin.cmd_buttons, F.data == "menu_buttons", F.from_user.id == ADMIN_ID)
+        dp.callback_query.register(admin.cmd_personalities, F.data == "menu_personalities", F.from_user.id == ADMIN_ID)
         dp.callback_query.register(admin.show_buttons_for_delete, F.data == "btn_del", F.from_user.id == ADMIN_ID)
         dp.callback_query.register(admin.show_buttons_for_edit, F.data == "btn_edit", F.from_user.id == ADMIN_ID)
         dp.callback_query.register(admin.process_button_add, F.data == "btn_add", F.from_user.id == ADMIN_ID)
@@ -31,6 +33,11 @@ def register_handlers(dp: Dispatcher, personality: str) -> None:
             F.data.startswith("editbtn:"),
             F.from_user.id == ADMIN_ID,
             StateFilter("*"),
+        )
+        dp.callback_query.register(
+            admin.process_personality_select,
+            F.data.startswith("pers_edit:"),
+            F.from_user.id == ADMIN_ID,
         )
         dp.callback_query.register(admin.cmd_kuplinov_menu, F.data == "menu_kuplinov", F.from_user.id == ADMIN_ID)
         dp.callback_query.register(admin.process_kp_add, F.data == "kp_add", F.from_user.id == ADMIN_ID)
@@ -44,6 +51,7 @@ def register_handlers(dp: Dispatcher, personality: str) -> None:
         dp.message.register(admin.process_button_label, ButtonAddState.waiting_label)
         dp.message.register(admin.process_button_response, ButtonAddState.waiting_response)
         dp.message.register(admin.process_button_edit_response, ButtonEditState.waiting_response)
+        dp.message.register(admin.process_personality_text, PersonalityEditState.waiting_text)
         dp.message.register(admin.process_kp_add_id, KuplinovAddState.waiting_id)
         dp.message.register(admin.process_kp_del_id, KuplinovDelState.waiting_id)
 

--- a/bot/history.py
+++ b/bot/history.py
@@ -1,3 +1,4 @@
+import json
 from redis.asyncio import Redis
 
 from .config import REDIS_URL
@@ -6,20 +7,39 @@ from .config import REDIS_URL
 redis: Redis
 redis = Redis.from_url(REDIS_URL, decode_responses=True)
 
+
 async def init_history() -> None:
     ...
 
 
-
-async def add_message(chat_id: int, text: str) -> None:
-    key = f"chat:{chat_id}:history"
-    await redis.rpush(key, text)
-    await redis.ltrim(key, -100, -1)
+async def add_message(
+    chat_id: int, msg_id: int, text: str, reply_to: int | None = None
+) -> None:
+    hist_key = f"chat:{chat_id}:history"
+    await redis.rpush(hist_key, text)
+    await redis.ltrim(hist_key, -100, -1)
+    msg_key = f"chat:{chat_id}:messages"
+    data = {"text": text, "reply": reply_to or 0}
+    await redis.hset(msg_key, msg_id, json.dumps(data))
 
 
 async def get_history(chat_id: int, limit: int = 10) -> list[str]:
     key = f"chat:{chat_id}:history"
     return await redis.lrange(key, -limit, -1)
+
+
+async def get_thread(chat_id: int, msg_id: int) -> list[str]:
+    msg_key = f"chat:{chat_id}:messages"
+    texts: list[str] = []
+    current = msg_id
+    while current:
+        raw = await redis.hget(msg_key, current)
+        if not raw:
+            break
+        data = json.loads(raw)
+        texts.append(data.get("text", ""))
+        current = data.get("reply") or 0
+    return list(reversed(texts))
 
 
 async def increment_count(chat_id: int, msg_id: int) -> bool:

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -1,11 +1,14 @@
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
+from .config import PROMPTS_DIR
+
 
 def main_menu():
     builder = InlineKeyboardBuilder()
     builder.button(text="Приветствие", callback_data="menu_greeting")
     builder.button(text="Вопрос", callback_data="menu_question")
     builder.button(text="Кнопки", callback_data="menu_buttons")
+    builder.button(text="Личности", callback_data="menu_personalities")
     builder.button(text="/kuplinov", callback_data="menu_kuplinov")
     builder.button(text="Предпросмотр", callback_data="menu_preview")
     builder.adjust(1)
@@ -27,6 +30,16 @@ def kuplinov_menu():
     builder.button(text="Добавить пользователя", callback_data="kp_add")
     builder.button(text="Удалить пользователя", callback_data="kp_del")
     builder.button(text="Список", callback_data="kp_list")
+    builder.button(text="Назад", callback_data="back_main")
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def personalities_menu():
+    builder = InlineKeyboardBuilder()
+    for file in sorted(PROMPTS_DIR.glob("*.txt")):
+        name = file.stem
+        builder.button(text=name, callback_data=f"pers_edit:{name}")
     builder.button(text="Назад", callback_data="back_main")
     builder.adjust(1)
     return builder.as_markup()

--- a/bot/states.py
+++ b/bot/states.py
@@ -24,3 +24,7 @@ class KuplinovAddState(StatesGroup):
 
 class KuplinovDelState(StatesGroup):
     waiting_id = State()
+
+
+class PersonalityEditState(StatesGroup):
+    waiting_text = State()

--- a/tests/test_prompt_building.py
+++ b/tests/test_prompt_building.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.handlers.common import _build_prompt
+
+
+def test_build_prompt_combines_priority_and_context():
+    system, user = _build_prompt(
+        "JoePeach", "ctx line1\nctx line2", "priority message", ""
+    )
+    assert "Сначала идет сообщение пользователя" in system
+    assert user.startswith("priority message")
+    assert "ctx line1" in user
+    assert "ctx line2" in user
+
+
+def test_build_prompt_only_context_when_no_priority():
+    system, user = _build_prompt("JoePeach", "ctx only", "", "")
+    assert user == "ctx only"

--- a/tests/test_random_trigger.py
+++ b/tests/test_random_trigger.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.handlers.common import should_count_for_random
+
+
+class DummyChat:
+    def __init__(self, type_):
+        self.type = type_
+
+
+class DummyMessage:
+    def __init__(self, chat_type, text):
+        self.chat = DummyChat(chat_type)
+        self.text = text
+
+
+def test_should_count_private():
+    msg = DummyMessage("private", "hello world" * 2)
+    assert should_count_for_random(msg, "JoePeach")
+
+
+def test_should_count_group():
+    msg = DummyMessage("group", "hello world" * 2)
+    assert should_count_for_random(msg, "JoePeach")
+
+
+def test_should_not_count_channel():
+    msg = DummyMessage("channel", "hello world" * 2)
+    assert not should_count_for_random(msg, "JoePeach")
+
+
+def test_should_not_count_short_text():
+    msg = DummyMessage("private", "hi")
+    assert not should_count_for_random(msg, "JoePeach")
+
+
+def test_should_not_count_other_personality():
+    msg = DummyMessage("private", "hello world" * 2)
+    assert not should_count_for_random(msg, "Kuplinov")


### PR DESCRIPTION
## Summary
- Refactor personalities into classes and expose helper registry
- Add admin UI to edit personality prompts dynamically
- Track message threads in Redis to build dialogue context and support command args
- Always mix chat history after user-provided arguments or reply text for smarter prompting
- Count messages for random auto-replies across private and group chats while ignoring bots

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dd727723c83208361f9d8fe0b7a58