### PR TITLE
Store conversation roles in Redis

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -23,6 +23,8 @@ _GROUP_ID_SINGLE = os.getenv("GROUP_ID", "0").strip()
 DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY", "")
 DB_PATH = Path(os.getenv("DB_PATH", "data/bot.db"))
 DEEPSEEK_URL = "https://api.deepseek.com/v1/chat/completions"
+DEEPSEEK_TEMPERATURE = float(os.getenv("DEEPSEEK_TEMPERATURE", "0.7"))
+DEEPSEEK_PRESENCE_PENALTY = float(os.getenv("DEEPSEEK_PRESENCE_PENALTY", "1"))
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 PROMPTS_DIR = Path(os.getenv("PROMPTS_DIR", "data/prompts"))
 

--- a/bot/history.py
+++ b/bot/history.py
@@ -13,33 +13,81 @@ async def init_history() -> None:
 
 
 async def add_message(
-    chat_id: int, msg_id: int, text: str, reply_to: int | None = None
+    chat_id: int,
+    msg_id: int,
+    text: str,
+    reply_to: int | None = None,
+    *,
+    role: str = "user",
+    name: str | None = None,
 ) -> None:
+    """Store a message in Redis with role-based metadata.
+
+    Messages are stored twice:
+    - in a list for quick retrieval of the last messages
+    - in a hash with reply mapping for building threads
+    """
+
     hist_key = f"chat:{chat_id}:history"
-    await redis.rpush(hist_key, text)
+    msg_data: dict[str, str | int] = {"role": role, "content": text}
+    if name:
+        msg_data["name"] = name
+    await redis.rpush(hist_key, json.dumps(msg_data))
     await redis.ltrim(hist_key, -100, -1)
+
     msg_key = f"chat:{chat_id}:messages"
-    data = {"text": text, "reply": reply_to or 0}
+    data = {"role": role, "content": text, "reply": reply_to or 0}
+    if name:
+        data["name"] = name
     await redis.hset(msg_key, msg_id, json.dumps(data))
 
 
-async def get_history(chat_id: int, limit: int = 10) -> list[str]:
+async def get_history(chat_id: int, limit: int = 10) -> list[dict]:
+    """Return the last messages for a chat as role-based dicts."""
+
     key = f"chat:{chat_id}:history"
-    return await redis.lrange(key, -limit, -1)
+    raw_messages = await redis.lrange(key, -limit, -1)
+    messages: list[dict] = []
+    for raw in raw_messages:
+        try:
+            data = json.loads(raw)
+            if not isinstance(data, dict):
+                raise ValueError
+        except Exception:
+            # Fall back to treating the raw string as a user message
+            data = {"role": "user", "content": raw}
+        msg: dict[str, str] = {
+            "role": data.get("role", "user"),
+            "content": data.get("content", ""),
+        }
+        name = data.get("name")
+        if name:
+            msg["name"] = name
+        messages.append(msg)
+    return messages
 
 
-async def get_thread(chat_id: int, msg_id: int) -> list[str]:
+async def get_thread(chat_id: int, msg_id: int) -> list[dict]:
+    """Return a message thread starting at ``msg_id`` as role-based dicts."""
+
     msg_key = f"chat:{chat_id}:messages"
-    texts: list[str] = []
+    msgs: list[dict] = []
     current = msg_id
     while current:
         raw = await redis.hget(msg_key, current)
         if not raw:
             break
         data = json.loads(raw)
-        texts.append(data.get("text", ""))
+        msg: dict[str, str] = {
+            "role": data.get("role", "user"),
+            "content": data.get("content", ""),
+        }
+        name = data.get("name")
+        if name:
+            msg["name"] = name
+        msgs.append(msg)
         current = data.get("reply") or 0
-    return list(reversed(texts))
+    return list(reversed(msgs))
 
 
 async def increment_count(chat_id: int, msg_id: int) -> bool:


### PR DESCRIPTION
## Summary
- Return history and thread data from Redis as role-tagged dictionaries
- Build DeepSeek API payload from stored user and assistant messages using a new system prompt helper
- Send full role-based chat history to DeepSeek instead of a single combined message
- Add configurable temperature and presence penalty to DeepSeek requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e34c20cec8320bd2d727c0f2beb2b