### PR TITLE
Include message names for all roles in personality responses

### DIFF
--- a/bot/handlers/common.py
+++ b/bot/handlers/common.py
@@ -227,8 +227,9 @@ async def respond_with_personality(
     _msgs = [{"role": "system", "content": system_prompt}]
     for msg in history:
         item = {"role": msg.get("role", "user"), "content": msg.get("content", "")}
-        if item["role"] == "assistant" and msg.get("name"):
-            item["name"] = msg["name"]
+        name = msg.get("name")
+        if name:
+            item["name"] = name
         _msgs.append(item)
 
     payload = {
@@ -296,8 +297,9 @@ async def respond_with_personality_to_chat(
     _msgs = [{"role": "system", "content": system_prompt}]
     for msg in history:
         item = {"role": msg.get("role", "user"), "content": msg.get("content", "")}
-        if item["role"] == "assistant" and msg.get("name"):
-            item["name"] = msg["name"]
+        name = msg.get("name")
+        if name:
+            item["name"] = name
         _msgs.append(item)
 
     payload = {


### PR DESCRIPTION
## Summary
- add message sender name to API prompts regardless of role
- confirm chat history utilities already return names for all roles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f2908f4708320917d20ee1bd7e56d