### PR TITLE
Embed speaker names into DeepSeek messages

### DIFF
--- a/tests/test_history_to_messages.py
+++ b/tests/test_history_to_messages.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.handlers.common import _history_to_messages
+
+
+def test_history_to_messages_adds_name_to_content():
+    history = [
+        {"role": "user", "content": "привет", "name": "Вася"},
+        {"role": "assistant", "content": "привет", "name": "Бот"},
+    ]
+    msgs = _history_to_messages("sys", history)
+    assert msgs[1]["content"] == "Вася: привет"
+    assert msgs[1]["name"] == "Вася"
+    assert msgs[2]["content"] == "Бот: привет"
+    assert msgs[2]["name"] == "Бот"
+
+
+def test_history_to_messages_without_name():
+    history = [{"role": "user", "content": "hi"}]
+    msgs = _history_to_messages("sys", history)
+    assert msgs[1] == {"role": "user", "content": "hi"}


### PR DESCRIPTION
## Summary
- include speaker names in conversation messages sent to DeepSeek
- test message building with and without name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f2c43d3a883208c01034c8e0bcb8c