### PR TITLE
Reply commands to original message

### DIFF
--- a/bot/handlers/common.py
+++ b/bot/handlers/common.py
@@ -343,7 +343,12 @@ async def cmd_kuplinov(message: Message) -> None:
         await message.delete()
     except Exception:
         pass
-    await respond_with_personality(message, "Kuplinov", priority)
+    await respond_with_personality(
+        message,
+        "Kuplinov",
+        priority,
+        reply_to=message.reply_to_message,
+    )
 
 
 async def cmd_joepeach(message: Message) -> None:
@@ -352,7 +357,12 @@ async def cmd_joepeach(message: Message) -> None:
         await message.delete()
     except Exception:
         pass
-    await respond_with_personality(message, "JoePeach", priority)
+    await respond_with_personality(
+        message,
+        "JoePeach",
+        priority,
+        reply_to=message.reply_to_message,
+    )
 
 
 async def cmd_mrazota(message: Message) -> None:
@@ -365,6 +375,7 @@ async def cmd_mrazota(message: Message) -> None:
         message,
         "Mrazota",
         priority,
+        reply_to=message.reply_to_message,
         additional_context="Ты можешь разделить ответ на несколько строк на основе </br> в тексте ответа. Обязательно используй это. Не больше трех отдельных строк!!!!",
     )
 

--- a/tests/test_command_reply.py
+++ b/tests/test_command_reply.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import asyncio
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.handlers import common
+
+
+class DummyMessage:
+    def __init__(self, reply_to_message=None):
+        self.reply_to_message = reply_to_message
+    async def delete(self):
+        pass
+
+def test_command_replies_to_original(monkeypatch):
+    original = SimpleNamespace(text="hi", message_id=123)
+    msg = DummyMessage(reply_to_message=original)
+    mock = AsyncMock()
+    monkeypatch.setattr(common, "respond_with_personality", mock)
+    asyncio.run(common.cmd_kuplinov(msg))
+    mock.assert_awaited_once()
+    assert mock.call_args.kwargs.get("reply_to") is original


### PR DESCRIPTION
## Summary
- Ensure command handlers reply to the message they were invoked on, not to the command message.
- Add unit test confirming command reply behavior.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f322159608320bd61848d7ac8bc94