### PR TITLE
Fix history messages to avoid name prefixes

### DIFF
--- a/bot/handlers/common.py
+++ b/bot/handlers/common.py
@@ -173,16 +173,16 @@ def _build_system_prompt(personality_key: str, additional_context: str | None) -
 
 
 def _history_to_messages(system_prompt: str, history: list[dict]) -> list[dict]:
-    """Build the message list for the DeepSeek API, embedding names into content."""
+    """Build the message list for the DeepSeek API, keeping names separate."""
     messages = [{"role": "system", "content": system_prompt}]
     for msg in history:
-        content = msg.get("content", "")
+        item = {
+            "role": msg.get("role", "user"),
+            "content": msg.get("content", ""),
+        }
         name = msg.get("name")
-        item = {"role": msg.get("role", "user")}
         if name:
-            content = f"{name}: {content}"
             item["name"] = name
-        item["content"] = content
         messages.append(item)
     return messages
 

--- a/tests/test_history_to_messages.py
+++ b/tests/test_history_to_messages.py
@@ -6,16 +6,14 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from bot.handlers.common import _history_to_messages
 
 
-def test_history_to_messages_adds_name_to_content():
+def test_history_to_messages_preserves_name():
     history = [
         {"role": "user", "content": "привет", "name": "Вася"},
         {"role": "assistant", "content": "привет", "name": "Бот"},
     ]
     msgs = _history_to_messages("sys", history)
-    assert msgs[1]["content"] == "Вася: привет"
-    assert msgs[1]["name"] == "Вася"
-    assert msgs[2]["content"] == "Бот: привет"
-    assert msgs[2]["name"] == "Бот"
+    assert msgs[1] == {"role": "user", "content": "привет", "name": "Вася"}
+    assert msgs[2] == {"role": "assistant", "content": "привет", "name": "Бот"}
 
 
 def test_history_to_messages_without_name():


### PR DESCRIPTION
## Summary
- stop injecting author names into message content when building history
- adjust tests for new message format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f3679baf0832089a8ef390b2d7343