### PR TITLE
feat: add tarot reading command for Mrazota

### DIFF
--- a/bot/handlers/__init__.py
+++ b/bot/handlers/__init__.py
@@ -63,5 +63,6 @@ def register_handlers(dp: Dispatcher, personality: str) -> None:
         dp.message.register(common.cmd_joepeach, Command("joepeach"))
     elif personality == "Mrazota":
         dp.message.register(common.cmd_mrazota, Command("mrazota"))
+        dp.message.register(common.cmd_taro, Command("taro"))
     dp.callback_query.register(common.on_button, F.data.startswith("btn:"))
     dp.message.register(partial(common.handle_message, personality_key=personality), F.text)

--- a/bot/tarot.py
+++ b/bot/tarot.py
@@ -1,0 +1,32 @@
+import random
+
+MAJOR_ARCANA = [
+    "Шут",
+    "Маг",
+    "Верховная Жрица",
+    "Императрица",
+    "Император",
+    "Иерофант",
+    "Влюбленные",
+    "Колесница",
+    "Сила",
+    "Отшельник",
+    "Колесо Фортуны",
+    "Справедливость",
+    "Повешенный",
+    "Смерть",
+    "Умеренность",
+    "Дьявол",
+    "Башня",
+    "Звезда",
+    "Луна",
+    "Солнце",
+    "Страшный Суд",
+    "Мир",
+]
+
+
+def draw_cards(count: int = 3) -> list[str]:
+    """Return ``count`` unique tarot card names."""
+    count = max(1, min(count, len(MAJOR_ARCANA)))
+    return random.sample(MAJOR_ARCANA, count)

--- a/tests/test_taro_command.py
+++ b/tests/test_taro_command.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+import sys
+import asyncio
+from unittest.mock import AsyncMock
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.handlers import common
+
+
+class DummyMessage:
+    def __init__(self, text="", reply_to_message=None):
+        self.text = text
+        self.reply_to_message = reply_to_message
+        self.chat = SimpleNamespace(id=1, type="private")
+        self.from_user = SimpleNamespace(id=123)
+        self.replied = None
+
+    async def reply(self, text):
+        self.replied = text
+
+
+def test_taro_calls_respond(monkeypatch):
+    original = DummyMessage(text="стоит ли продолжать?")
+    msg = DummyMessage(text="/taro", reply_to_message=original)
+    monkeypatch.setattr(common, "draw_cards", lambda n: ["Карта1", "Карта2", "Карта3"])
+    mock = AsyncMock()
+    monkeypatch.setattr(common, "respond_with_personality", mock)
+    asyncio.run(common.cmd_taro(msg))
+    assert original.replied == "Выпали карты: Карта1, Карта2, Карта3"
+    mock.assert_awaited_once()
+    args, kwargs = mock.call_args
+    assert args[0] is msg
+    assert args[1] == "Mrazota"
+    assert args[2] == "стоит ли продолжать?"
+    assert kwargs["reply_to"] is original
+    assert "Карта1, Карта2, Карта3" in kwargs["additional_context"]
+    assert "Сейчас ты гадаешь на таро" in kwargs["additional_context"]
+    assert kwargs["model"] == "deepseek-reasoner"


### PR DESCRIPTION
## Summary
- allow choosing DeepSeek model per personality response
- restrict `/taro` prompt to card interpretations and use `deepseek-reasoner`
- update tests for new prompt and model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af39de71188320aa03d3966e8ea4b1