### PR TITLE
Fix replying to comments instead of posts

### DIFF
--- a/bot/handlers/common.py
+++ b/bot/handlers/common.py
@@ -240,6 +240,10 @@ async def respond_with_personality(
     headers = {"Authorization": f"Bearer {DEEPSEEK_API_KEY}"}
 
     _msgs = _history_to_messages(system_prompt, history)
+    if priority_text and (
+        not history or history[-1].get("content") != priority_text
+    ):
+        _msgs.append({"role": "user", "content": priority_text})
 
     payload = {
         "model": model,
@@ -311,6 +315,10 @@ async def respond_with_personality_to_chat(
     system_prompt = _build_system_prompt(personality_key, additional_context)
     headers = {"Authorization": f"Bearer {DEEPSEEK_API_KEY}"}
     _msgs = _history_to_messages(system_prompt, history)
+    if priority_text and (
+        not history or history[-1].get("content") != priority_text
+    ):
+        _msgs.append({"role": "user", "content": priority_text})
 
     payload = {
         "model": model,
@@ -464,7 +472,7 @@ async def handle_message(message: Message, personality_key: str) -> None:
             message,
             personality_key,
             message.text,
-            reply_to=message.reply_to_message,
+            reply_to=message,
             reply_to_comment=message,
         )
         return

--- a/tests/test_mrazota_comment_reply.py
+++ b/tests/test_mrazota_comment_reply.py
@@ -39,6 +39,7 @@ def test_comment_triggers_mrazota(monkeypatch):
 
     asyncio.run(run_handle(msg))
     mock.assert_awaited_once()
-    _, kwargs = mock.call_args
-    assert kwargs["reply_to"] is post
+    args, kwargs = mock.call_args
+    assert args[2] == msg.text
+    assert kwargs["reply_to"] is msg
     assert kwargs["reply_to_comment"] is msg

--- a/tests/test_priority_text_usage.py
+++ b/tests/test_priority_text_usage.py
@@ -1,0 +1,43 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import asyncio
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.handlers import common
+
+class DummyBot:
+    async def send_chat_action(self, chat_id, action):
+        pass
+
+class DummyMessage:
+    def __init__(self, text="hi", chat=None, message_id=1):
+        self.text = text
+        self.chat = chat or SimpleNamespace(id=1, type="group")
+        self.message_id = message_id
+        self.from_user = SimpleNamespace(id=123)
+        self.bot = DummyBot()
+    async def reply(self, text):
+        return SimpleNamespace(message_id=42)
+    async def answer(self, text):
+        return SimpleNamespace(message_id=43)
+
+
+def test_priority_text_included(monkeypatch):
+    msg = DummyMessage(text="comment text")
+    monkeypatch.setattr(common, "is_group_allowed", lambda cid: True)
+    monkeypatch.setattr(common, "get_thread", AsyncMock(return_value=[]))
+    monkeypatch.setattr(common, "get_history", AsyncMock(return_value=[]))
+    monkeypatch.setattr(common, "add_message", AsyncMock())
+
+    captured = {}
+    async def fake_post(url, json_payload, headers, max_attempts=3, timeout=30):
+        captured['payload'] = json_payload
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    monkeypatch.setattr(common, "_httpx_post_with_retries", fake_post)
+    asyncio.run(common.respond_with_personality(msg, "Mrazota", msg.text, reply_to=msg, reply_to_comment=msg))
+    messages = captured['payload']['messages']
+    assert messages[-1]["content"] == msg.text


### PR DESCRIPTION
## Summary
- include comment text when building personality response payloads
- verify comment text is passed to personality responder and included in prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfdac8ea448320bee963479c2a2a49