### PR TITLE
Combine rapid comment messages

### DIFF
--- a/tests/test_mrazota_comment_reply.py
+++ b/tests/test_mrazota_comment_reply.py
@@ -26,7 +26,7 @@ async def run_handle(message):
 
 def test_comment_triggers_mrazota(monkeypatch):
     post = SimpleNamespace(message_id=10, is_automatic_forward=True, sender_chat=SimpleNamespace(type="channel"))
-    user = SimpleNamespace(is_bot=False, full_name="User")
+    user = SimpleNamespace(is_bot=False, full_name="User", id=1)
     bot = SimpleNamespace(id=999)
     msg = DummyMessage("hi", reply_to_message=post, from_user=user, bot=bot, message_id=20)
 
@@ -37,9 +37,44 @@ def test_comment_triggers_mrazota(monkeypatch):
     monkeypatch.setattr(common, "increment_count", AsyncMock(return_value=False))
     monkeypatch.setattr(common, "should_count_for_random", lambda m, p: False)
 
-    asyncio.run(run_handle(msg))
+    monkeypatch.setattr(common, "COMMENT_MERGE_WINDOW", 0.01)
+
+    async def run():
+        await common.handle_message(msg, "Mrazota")
+        await asyncio.sleep(0.02)
+
+    asyncio.run(run())
     mock.assert_awaited_once()
     args, kwargs = mock.call_args
     assert args[2] == msg.text
     assert kwargs["reply_to"] is msg
     assert kwargs["reply_to_comment"] is msg
+
+
+def test_multiple_comments_combined(monkeypatch):
+    post = SimpleNamespace(message_id=10, is_automatic_forward=True, sender_chat=SimpleNamespace(type="channel"))
+    user = SimpleNamespace(is_bot=False, full_name="User", id=1)
+    bot = SimpleNamespace(id=999)
+    msg1 = DummyMessage("hi", reply_to_message=post, from_user=user, bot=bot, message_id=20)
+    msg2 = DummyMessage("there", reply_to_message=post, from_user=user, bot=bot, message_id=21)
+
+    mock = AsyncMock()
+    monkeypatch.setattr(common, "respond_with_personality", mock)
+    monkeypatch.setattr(common, "is_group_allowed", lambda chat_id: True)
+    monkeypatch.setattr(common, "add_message", AsyncMock())
+    monkeypatch.setattr(common, "increment_count", AsyncMock(return_value=False))
+    monkeypatch.setattr(common, "should_count_for_random", lambda m, p: False)
+    monkeypatch.setattr(common, "COMMENT_MERGE_WINDOW", 0.01)
+
+    async def run():
+        await common.handle_message(msg1, "Mrazota")
+        await asyncio.sleep(0.005)
+        await common.handle_message(msg2, "Mrazota")
+        await asyncio.sleep(0.02)
+
+    asyncio.run(run())
+    mock.assert_awaited_once()
+    args, kwargs = mock.call_args
+    assert args[2] == f"{msg1.text} {msg2.text}"
+    assert kwargs["reply_to"] is msg2
+    assert kwargs["reply_to_comment"] is msg2


### PR DESCRIPTION
## Summary
- group quick successive comment messages into a single combined text for Mrazota replies
- buffer comments for 10 seconds and reply only to the last message
- add tests for comment buffering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2921fc8c4832085aac3125c8684c6