### PR TITLE
Scope chat histories by user and thread

### DIFF
--- a/bot/auto_reply.py
+++ b/bot/auto_reply.py
@@ -24,14 +24,20 @@ async def listen_auto_replies(bot: Bot, personality: str) -> None:
         if data.get("personality") != personality:
             continue
         chat_id = data.get("chat_id")
+        user_id = data.get("user_id")
+        thread_id = data.get("thread_id")
         msg_id = data.get("msg_id")
         text = data.get("text", "")
+        if not isinstance(thread_id, int):
+            thread_id = 0
         if not isinstance(chat_id, int) or not isinstance(msg_id, int):
             continue
         try:
             await respond_with_personality_to_chat(
                 bot,
                 chat_id,
+                int(user_id or 0),
+                thread_id,
                 personality,
                 text,
                 reply_to_message_id=msg_id,

--- a/tests/test_mrazota_comment_reply.py
+++ b/tests/test_mrazota_comment_reply.py
@@ -13,13 +13,23 @@ class DummyChat:
         self.id = id
 
 class DummyMessage:
-    def __init__(self, text, reply_to_message=None, chat=None, message_id=1, from_user=None, bot=None):
+    def __init__(
+        self,
+        text,
+        reply_to_message=None,
+        chat=None,
+        message_id=1,
+        from_user=None,
+        bot=None,
+        thread_id=0,
+    ):
         self.text = text
         self.reply_to_message = reply_to_message
         self.chat = chat or DummyChat()
         self.message_id = message_id
         self.from_user = from_user
         self.bot = bot
+        self.message_thread_id = thread_id
 
 async def run_handle(message):
     await common.handle_message(message, "Mrazota")

--- a/tests/test_priority_text_usage.py
+++ b/tests/test_priority_text_usage.py
@@ -13,10 +13,11 @@ class DummyBot:
         pass
 
 class DummyMessage:
-    def __init__(self, text="hi", chat=None, message_id=1):
+    def __init__(self, text="hi", chat=None, message_id=1, thread_id=0):
         self.text = text
         self.chat = chat or SimpleNamespace(id=1, type="group")
         self.message_id = message_id
+        self.message_thread_id = thread_id
         self.from_user = SimpleNamespace(id=123)
         self.bot = DummyBot()
     async def reply(self, text):

--- a/tests/test_taro_command.py
+++ b/tests/test_taro_command.py
@@ -10,12 +10,13 @@ from bot.handlers import common
 
 
 class DummyMessage:
-    def __init__(self, text="", reply_to_message=None):
+    def __init__(self, text="", reply_to_message=None, thread_id=0):
         self.text = text
         self.reply_to_message = reply_to_message
         self.chat = SimpleNamespace(id=1, type="private")
         self.from_user = SimpleNamespace(id=123)
         self.replied = None
+        self.message_thread_id = thread_id
 
     async def reply(self, text):
         self.replied = text


### PR DESCRIPTION
## Summary
- track chat history per user and thread in Redis
- propagate user and thread IDs through message handlers and auto-reply logic
- update tests for new parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2da96bb948320a569f008a516d9e8