### PR TITLE
Fix missing history for comment replies

### DIFF
--- a/bot/handlers/common.py
+++ b/bot/handlers/common.py
@@ -238,7 +238,7 @@ async def respond_with_personality(
         await asyncio.sleep(random.uniform(*delay_range))
     await message.bot.send_chat_action(message.chat.id, "typing")
     logger.info(f"[REQUEST] personality={personality_key} user={user.id}")
-    if reply_to:
+    if reply_to and not reply_to_comment:
         history = await get_thread(
             message.chat.id, user_id, thread_id, reply_to.message_id
         )


### PR DESCRIPTION
## Summary
- use user/thread history instead of per-message threads when replying to comments
- test that comment replies consult stored history

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2e3bf8d04832094e46f9bad9cba31