### PR TITLE
Add global user ban command

### DIFF
--- a/bot/handlers/__init__.py
+++ b/bot/handlers/__init__.py
@@ -64,5 +64,6 @@ def register_handlers(dp: Dispatcher, personality: str) -> None:
     elif personality == "Mrazota":
         dp.message.register(common.cmd_mrazota, Command("mrazota"))
         dp.message.register(common.cmd_taro, Command("taro"))
+        dp.message.register(common.cmd_ban, Command("ban"), F.from_user.id == ADMIN_ID)
     dp.callback_query.register(common.on_button, F.data.startswith("btn:"))
     dp.message.register(partial(common.handle_message, personality_key=personality), F.text)

--- a/tests/test_ban.py
+++ b/tests/test_ban.py
@@ -1,0 +1,51 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import asyncio
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.handlers import common
+from bot.config import ADMIN_ID
+
+
+class DummyChat:
+    def __init__(self, id=1):
+        self.id = id
+
+
+class DummyMessage:
+    def __init__(self, text="", from_user=None, reply_to_message=None, chat=None, bot=None):
+        self.text = text
+        self.from_user = from_user
+        self.reply_to_message = reply_to_message
+        self.chat = chat or DummyChat()
+        self.bot = bot
+        self.message_id = 1
+        self.message_thread_id = 0
+
+    async def delete(self):
+        pass
+
+
+def test_cmd_ban_adds_user(monkeypatch):
+    admin = SimpleNamespace(id=ADMIN_ID)
+    target = SimpleNamespace(id=123)
+    reply = SimpleNamespace(from_user=target)
+    msg = DummyMessage(text="/ban", from_user=admin, reply_to_message=reply)
+    add_mock = AsyncMock()
+    monkeypatch.setattr(common, "add_banned_user", add_mock)
+    asyncio.run(common.cmd_ban(msg))
+    add_mock.assert_awaited_once_with(target.id)
+
+
+def test_handle_message_skips_banned(monkeypatch):
+    user = SimpleNamespace(id=55, is_bot=False, full_name="User")
+    msg = DummyMessage(text="hi", from_user=user)
+    monkeypatch.setattr(common, "is_group_allowed", lambda chat_id: True)
+    monkeypatch.setattr(common, "is_banned", AsyncMock(return_value=True))
+    add_message_mock = AsyncMock()
+    monkeypatch.setattr(common, "add_message", add_message_mock)
+    asyncio.run(common.handle_message(msg, "Mrazota"))
+    add_message_mock.assert_not_awaited()

--- a/tests/test_command_reply.py
+++ b/tests/test_command_reply.py
@@ -9,9 +9,16 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from bot.handlers import common
 
 
+class DummyUser:
+    def __init__(self, id=1):
+        self.id = id
+
+
 class DummyMessage:
-    def __init__(self, reply_to_message=None):
+    def __init__(self, reply_to_message=None, from_user=None):
         self.reply_to_message = reply_to_message
+        self.from_user = from_user or DummyUser()
+
     async def delete(self):
         pass
 


### PR DESCRIPTION
## Summary
- Track banned users in SQLite to ignore their messages
- Add /ban admin command handled by Mrazota
- Skip processing of messages from banned users across bots

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3eb481fe48320a53a8310d89eb7dc